### PR TITLE
Use thinsp and en-dash in calendar time patterns

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/targets/CalendarTarget.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/targets/CalendarTarget.kt
@@ -125,7 +125,7 @@ class CalendarTarget: SmartspacerTargetProvider() {
             return resources.getString(R.string.target_calendar_subtitle_all_day)
         }
         return when {
-            startTime.isSameDay(now) && endTime.isSameDay(now) -> "$start - $end"
+            startTime.isSameDay(now) && endTime.isSameDay(now) -> "$start – $end"
             startTime.isYesterday(now) -> {
                 resources.getString(
                     R.string.target_calendar_subtitle_with_yesterday,
@@ -156,7 +156,7 @@ class CalendarTarget: SmartspacerTargetProvider() {
                     end
                 )
             }
-            else -> "$start - $end"
+            else -> "$start – $end"
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -944,10 +944,10 @@
     <string name="target_calendar_configuration_description">Configure which Calendars to display and options for when to show events</string>
     <string name="target_calendar_title_default">Untitled Event</string>
     <string name="target_calendar_title_with_time">%1s in %1dm</string>
-    <string name="target_calendar_subtitle_with_yesterday">Yesterday, %1s - %1s</string>
-    <string name="target_calendar_subtitle_with_tomorrow">%1s - Tomorrow, %1s</string>
-    <string name="target_calendar_subtitle_with_date_for_start">%1s, %1s - %1s</string>
-    <string name="target_calendar_subtitle_with_date_for_end">%1s - %1s, %1s</string>
+    <string name="target_calendar_subtitle_with_yesterday">Yesterday, %1s – %1s</string>
+    <string name="target_calendar_subtitle_with_tomorrow">%1s – Tomorrow, %1s</string>
+    <string name="target_calendar_subtitle_with_date_for_start">%1s, %1s – %1s</string>
+    <string name="target_calendar_subtitle_with_date_for_end">%1s – %1s, %1s</string>
     <string name="target_calendar_subtitle_all_day">All Day</string>
     <string name="target_calendar_settings_calendars">Select Calendars</string>
     <string name="target_calendar_settings_settings">Settings</string>


### PR DESCRIPTION
This is the correct way of formatting time ranges according to the Unicode CLDR.