### PR TITLE
1.3.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ plugins {
 
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
-def tagName = '1.3'
-def tagCode = 130
+def tagName = '1.3.1'
+def tagCode = 131
 
 android {
     compileSdk 34
@@ -77,13 +77,13 @@ dependencies {
     implementation 'androidx.core:core-splashscreen:1.0.1'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation "androidx.fragment:fragment-ktx:1.6.2"
-    implementation "androidx.activity:activity-ktx:1.8.0"
-    implementation "androidx.work:work-runtime-ktx:2.8.1"
+    implementation "androidx.activity:activity-ktx:1.8.1"
+    implementation "androidx.work:work-runtime-ktx:2.9.0"
     implementation "androidx.core:core-remoteviews:1.0.0"
     implementation "androidx.security:security-crypto:1.1.0-alpha06"
     implementation project(path: ':proto')
 
-    def room_version = "2.6.0"
+    def room_version = "2.6.1"
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     ksp "androidx.room:room-compiler:$room_version"
@@ -119,17 +119,17 @@ dependencies {
     implementation "com.github.topjohnwu.libsu:service:${libsuVersion}"
 
     //Dependency Injection
-    implementation "io.insert-koin:koin-android:3.4.0"
+    implementation "io.insert-koin:koin-android:3.5.0"
 
     implementation 'com.jakewharton:process-phoenix:2.1.2'
 
     //Image Loading
-    implementation 'com.github.bumptech.glide:glide:4.15.1'
+    implementation 'com.github.bumptech.glide:glide:4.16.0'
     ksp 'com.github.bumptech.glide:ksp:4.15.1'
 
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.android.gms:play-services-maps:18.2.0'
-    implementation 'com.google.maps.android:android-maps-utils:2.4.0'
+    implementation 'com.google.maps.android:android-maps-utils:3.8.0'
     implementation 'me.saket:better-link-movement-method:2.2.0'
 
     implementation 'com.airbnb.android:lottie:6.1.0'

--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -11,8 +11,8 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 122,
-      "versionName": "1.2.2",
+      "versionCode": 130,
+      "versionName": "1.3",
       "outputFile": "app-release.apk"
     }
   ],

--- a/app/src/androidTest/java/com/kieronquinn/app/smartspacer/repositories/CalendarRepositoryTests.kt
+++ b/app/src/androidTest/java/com/kieronquinn/app/smartspacer/repositories/CalendarRepositoryTests.kt
@@ -50,6 +50,7 @@ class CalendarRepositoryTests: BaseTest<CalendarRepository>() {
         ) = TargetData(
             randomString(),
             preEventTime,
+            TargetData.PostEventTime.AT_END,
             showAllDay,
             true,
             showUnconfirmed,

--- a/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/options/ExpandedWidgetOptionsBottomSheetViewModelTests.kt
+++ b/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/options/ExpandedWidgetOptionsBottomSheetViewModelTests.kt
@@ -14,6 +14,7 @@ import com.kieronquinn.app.smartspacer.utils.randomInt
 import com.kieronquinn.app.smartspacer.utils.randomString
 import io.mockk.coVerify
 import io.mockk.every
+import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -62,7 +63,7 @@ class ExpandedWidgetOptionsBottomSheetViewModelTests: BaseTest<ExpandedWidgetOpt
     fun testState() = runTest {
         sut.state.test {
             assertTrue(awaitItem() is State.Loading)
-            sut.setupWithWidgetId(mockWidgets.first().appWidgetId!!)
+            sut.setup(mockWidgets.first().appWidgetId!!, true)
             val item = awaitItem()
             assertTrue(item is State.Loaded)
         }
@@ -72,7 +73,7 @@ class ExpandedWidgetOptionsBottomSheetViewModelTests: BaseTest<ExpandedWidgetOpt
     fun testSetSpanX() = runTest {
         sut.state.test {
             assertTrue(awaitItem() is State.Loading)
-            sut.setupWithWidgetId(mockWidgets.first().appWidgetId!!)
+            sut.setup(mockWidgets.first().appWidgetId!!, true)
             val item = awaitItem()
             assertTrue(item is State.Loaded)
             val widget = sut.widget.value!!
@@ -89,7 +90,7 @@ class ExpandedWidgetOptionsBottomSheetViewModelTests: BaseTest<ExpandedWidgetOpt
     fun testSetSpanY() = runTest {
         sut.state.test {
             assertTrue(awaitItem() is State.Loading)
-            sut.setupWithWidgetId(mockWidgets.first().appWidgetId!!)
+            sut.setup(mockWidgets.first().appWidgetId!!, true)
             val item = awaitItem()
             assertTrue(item is State.Loaded)
             val widget = sut.widget.value!!
@@ -106,16 +107,39 @@ class ExpandedWidgetOptionsBottomSheetViewModelTests: BaseTest<ExpandedWidgetOpt
     fun testSetShowWhenLocked() = runTest {
         sut.state.test {
             assertTrue(awaitItem() is State.Loading)
-            sut.setupWithWidgetId(mockWidgets.first().appWidgetId!!)
+            sut.setup(mockWidgets.first().appWidgetId!!, true)
             val item = awaitItem()
             assertTrue(item is State.Loaded)
             val widget = sut.widget.value!!
-            val mock = randomFloat()
             sut.setShowWhenLocked(false)
             coVerify {
                 databaseRepositoryMock
                     .updateExpandedCustomAppWidget(widget.copy(showWhenLocked = false))
             }
+        }
+    }
+
+    @Test
+    fun testCanReconfigure() = runTest {
+        sut.state.test {
+            assertTrue(awaitItem() is State.Loading)
+            sut.setup(mockWidgets.first().appWidgetId!!, true)
+            val item = awaitItem()
+            assertTrue(item is State.Loaded)
+            item as State.Loaded
+            assertTrue(item.canReconfigure)
+        }
+    }
+
+    @Test
+    fun testCannotReconfigure() = runTest {
+        sut.state.test {
+            assertTrue(awaitItem() is State.Loading)
+            sut.setup(mockWidgets.first().appWidgetId!!, false)
+            val item = awaitItem()
+            assertTrue(item is State.Loaded)
+            item as State.Loaded
+            assertFalse(item.canReconfigure)
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/Smartspacer.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/Smartspacer.kt
@@ -463,10 +463,9 @@ class Smartspacer: Application(), Configuration.Provider {
         return getProcessName() != packageName
     }
 
-    override fun getWorkManagerConfiguration(): Configuration {
-        return Configuration.Builder()
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
             .setMaxSchedulerLimit(AlarmRepository.MAX_SCHEDULER_LIMIT)
             .build()
-    }
 
 }

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/ExpandedViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/ExpandedViewModel.kt
@@ -64,7 +64,7 @@ abstract class ExpandedViewModel: ViewModel() {
     abstract fun onAppShortcutClicked(appShortcut: AppShortcut)
     abstract fun onAddWidgetClicked()
     abstract fun onAppWidgetReset(appWidgetId: Int)
-    abstract fun onOptionsClicked(appWidgetId: Int)
+    abstract fun onOptionsClicked(appWidgetId: Int, canReconfigure: Boolean)
     abstract fun onRearrangeClicked()
 
     abstract fun onConfigureWidgetClicked(
@@ -384,9 +384,9 @@ class ExpandedViewModelImpl(
         }
     }
 
-    override fun onOptionsClicked(appWidgetId: Int) {
+    override fun onOptionsClicked(appWidgetId: Int, canReconfigure: Boolean) {
         viewModelScope.launch {
-            navigation.navigate(ExpandedFragmentDirections.actionExpandedFragmentToExpandedWidgetOptionsBottomSheetFragment(appWidgetId))
+            navigation.navigate(ExpandedFragmentDirections.actionExpandedFragmentToExpandedWidgetOptionsBottomSheetFragment(appWidgetId, canReconfigure))
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/options/ExpandedWidgetOptionsBottomSheetFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/options/ExpandedWidgetOptionsBottomSheetFragment.kt
@@ -2,6 +2,7 @@ package com.kieronquinn.app.smartspacer.ui.screens.expanded.options
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
@@ -26,6 +27,10 @@ class ExpandedWidgetOptionsBottomSheetFragment: BaseBottomSheetFragment<Fragment
     private val viewModel by viewModel<ExpandedWidgetOptionsBottomSheetViewModel>()
     private val args by navArgs<ExpandedWidgetOptionsBottomSheetFragmentArgs>()
 
+    private val configureLauncher = registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) {
+        //No-op
+    }
+
     private val adapter by lazy {
         Adapter()
     }
@@ -37,7 +42,7 @@ class ExpandedWidgetOptionsBottomSheetFragment: BaseBottomSheetFragment<Fragment
         setupInsets()
         setupClose()
         setupState()
-        viewModel.setupWithWidgetId(args.appWidgetId)
+        viewModel.setup(args.appWidgetId, args.canReconfigure)
     }
 
     private fun setupLoading() = with(binding.widgetOptionsLoading.loadingProgress){
@@ -97,7 +102,7 @@ class ExpandedWidgetOptionsBottomSheetFragment: BaseBottomSheetFragment<Fragment
     }
 
     private fun State.Loaded.loadItems(): List<BaseSettingsItem> {
-        return listOf(
+        return listOfNotNull(
             GenericSettingsItem.Slider(
                 spanX.toFloat(),
                 1f,
@@ -124,6 +129,16 @@ class ExpandedWidgetOptionsBottomSheetFragment: BaseBottomSheetFragment<Fragment
                 ::formatLabel,
                 viewModel::setSpanY
             ),
+            GenericSettingsItem.Setting(
+                getString(R.string.expanded_custom_widget_options_reconfigure_title),
+                getString(R.string.expanded_custom_widget_options_reconfigure_content),
+                ContextCompat.getDrawable(
+                    requireContext(), R.drawable.ic_configure
+                )
+            ) {
+                viewModel.onReconfigureClicked(configureLauncher)
+                dismiss()
+            }.takeIf { canReconfigure },
             GenericSettingsItem.SwitchSetting(
                 showWhenLocked,
                 getString(R.string.expanded_custom_widget_options_show_when_locked_title),

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/options/ExpandedWidgetOptionsBottomSheetViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/options/ExpandedWidgetOptionsBottomSheetViewModel.kt
@@ -1,9 +1,13 @@
 package com.kieronquinn.app.smartspacer.ui.screens.expanded.options
 
 import android.content.Context
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.core.app.ActivityOptionsCompat
 import com.kieronquinn.app.smartspacer.repositories.DatabaseRepository
 import com.kieronquinn.app.smartspacer.repositories.ExpandedRepository
 import com.kieronquinn.app.smartspacer.ui.base.BaseViewModel
+import com.kieronquinn.app.smartspacer.utils.extensions.allowBackground
 import com.kieronquinn.app.smartspacer.utils.extensions.lockscreenShowing
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -13,7 +17,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.jetbrains.annotations.VisibleForTesting
@@ -23,17 +26,19 @@ abstract class ExpandedWidgetOptionsBottomSheetViewModel(scope: CoroutineScope?)
     abstract val state: StateFlow<State>
     abstract val exitBus: Flow<Boolean>
 
-    abstract fun setupWithWidgetId(appWidgetId: Int)
+    abstract fun setup(appWidgetId: Int, canReconfigure: Boolean)
     abstract fun setSpanX(spanX: Float)
     abstract fun setSpanY(spanY: Float)
     abstract fun setShowWhenLocked(showWhenLocked: Boolean)
+    abstract fun onReconfigureClicked(configureLauncher: ActivityResultLauncher<IntentSenderRequest>)
 
     sealed class State {
-        object Loading: State()
+        data object Loading: State()
         data class Loaded(
             val spanX: Int,
             val spanY: Int,
-            val showWhenLocked: Boolean
+            val showWhenLocked: Boolean,
+            val canReconfigure: Boolean
         ): State()
     }
 
@@ -42,11 +47,12 @@ abstract class ExpandedWidgetOptionsBottomSheetViewModel(scope: CoroutineScope?)
 class ExpandedWidgetOptionsBottomSheetViewModelImpl(
     context: Context,
     private val databaseRepository: DatabaseRepository,
-    expandedRepository: ExpandedRepository,
+    private val expandedRepository: ExpandedRepository,
     scope: CoroutineScope? = null
 ): ExpandedWidgetOptionsBottomSheetViewModel(scope) {
 
     private val appWidgetId = MutableStateFlow<Int?>(null)
+    private val canReconfigure = MutableStateFlow<Boolean?>(null)
 
     @VisibleForTesting
     val widget = combine(
@@ -56,15 +62,19 @@ class ExpandedWidgetOptionsBottomSheetViewModelImpl(
         widgets.first { it.appWidgetId == id }
     }.stateIn(vmScope, SharingStarted.Eagerly, null)
 
-    override val state = widget.filterNotNull().mapLatest {
-        State.Loaded(it.spanX, it.spanY, it.showWhenLocked)
+    override val state = combine(
+        widget.filterNotNull(),
+        canReconfigure.filterNotNull()
+    ) { widget, reconfigure ->
+        State.Loaded(widget.spanX, widget.spanY, widget.showWhenLocked, reconfigure)
     }.stateIn(vmScope, SharingStarted.Eagerly, State.Loading)
 
     override val exitBus = context.lockscreenShowing().drop(1)
 
-    override fun setupWithWidgetId(appWidgetId: Int) {
+    override fun setup(appWidgetId: Int, canReconfigure: Boolean) {
         vmScope.launch {
             this@ExpandedWidgetOptionsBottomSheetViewModelImpl.appWidgetId.emit(appWidgetId)
+            this@ExpandedWidgetOptionsBottomSheetViewModelImpl.canReconfigure.emit(canReconfigure)
         }
     }
 
@@ -87,6 +97,16 @@ class ExpandedWidgetOptionsBottomSheetViewModelImpl(
         vmScope.launch {
             databaseRepository.updateExpandedCustomAppWidget(
                 widget.copy(showWhenLocked = showWhenLocked)
+            )
+        }
+    }
+
+    override fun onReconfigureClicked(configureLauncher: ActivityResultLauncher<IntentSenderRequest>) {
+        val appWidgetId = appWidgetId.value ?: return
+        expandedRepository.createConfigIntentSender(appWidgetId).also {
+            configureLauncher.launch(
+                IntentSenderRequest.Builder(it).build(),
+                ActivityOptionsCompat.makeBasic().allowBackground()
             )
         }
     }

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+RemoteViews.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+RemoteViews.kt
@@ -23,20 +23,19 @@ import dev.rikka.tools.refine.Refine
 import java.lang.reflect.Field
 import java.util.concurrent.CompletableFuture
 import kotlin.Pair
-import android.os.Parcelable as RemoteViewsAction
 import android.util.Pair as AndroidPair
 
 @Suppress("UNCHECKED_CAST")
 @SuppressLint("DiscouragedPrivateApi")
-private fun RemoteViews.getActions(): ArrayList<RemoteViewsAction>? {
+private fun RemoteViews.getActions(): ArrayList<Any>? {
     return RemoteViews::class.java.getDeclaredField("mActions").apply {
         isAccessible = true
-    }.get(this) as? ArrayList<RemoteViewsAction>
+    }.get(this) as? ArrayList<Any>
 }
 
 @Suppress("UNCHECKED_CAST")
 @SuppressLint("DiscouragedPrivateApi")
-fun RemoteViews.getActionsIncludingNested(): List<RemoteViewsAction> {
+fun RemoteViews.getActionsIncludingNested(): List<Any> {
     val myActions = getActions()?.toList() ?: emptyList()
     val sizedActions = getSizedRemoteViews().mapNotNull {
         it.getActions()
@@ -74,25 +73,25 @@ private val mApplicationField by lazy {
     RemoteViews::class.java.getField("mApplication")
 }
 
-fun RemoteViewsAction.isRemoteViewsAdapterIntent(): Boolean {
+fun Any.isRemoteViewsAdapterIntent(): Boolean {
     return this::class.java == setRemoteViewsAdapterIntentClass
 }
 
-fun RemoteViewsAction.isRemoteCollectionItemListAdapter(): Boolean {
+fun Any.isRemoteCollectionItemListAdapter(): Boolean {
     return this::class.java == setRemoteCollectionItemListAdapterClass
 }
 
-fun RemoteViewsAction.isOnClickResponse(): Boolean {
+fun Any.isOnClickResponse(): Boolean {
     return this::class.java == setOnClickResponseClass
 }
 
-fun RemoteViewsAction.getId(): Int {
+fun Any.getId(): Int {
     return actionClass.getDeclaredField("viewId", "mViewId").apply {
         isAccessible = true
     }.get(this) as Int
 }
 
-fun RemoteViewsAction.extractAdapterIntent(): Pair<Int, Intent> {
+fun Any.extractAdapterIntent(): Pair<Int, Intent> {
     val intent = setRemoteViewsAdapterIntentClass.getDeclaredField("intent", "mIntent").apply {
         isAccessible = true
     }.get(this) as Intent
@@ -100,7 +99,7 @@ fun RemoteViewsAction.extractAdapterIntent(): Pair<Int, Intent> {
 }
 
 @RequiresApi(Build.VERSION_CODES.S)
-fun RemoteViewsAction.extractRemoteCollectionItems(): Pair<Int, RemoteCollectionItems>? {
+fun Any.extractRemoteCollectionItems(): Pair<Int, RemoteCollectionItems>? {
     val items = setRemoteCollectionItemListAdapterClass.declaredFields.firstNotNullOfOrNull {
         when(it.name) {
             "mItems" -> getRemoteCollectItemsLegacy(it)
@@ -112,7 +111,7 @@ fun RemoteViewsAction.extractRemoteCollectionItems(): Pair<Int, RemoteCollection
 }
 
 @RequiresApi(Build.VERSION_CODES.S)
-private fun RemoteViewsAction.getRemoteCollectItemsLegacy(field: Field): RemoteCollectionItems {
+private fun Any.getRemoteCollectItemsLegacy(field: Field): RemoteCollectionItems {
     return field.let {
         it.isAccessible = true
         it.get(this) as RemoteCollectionItems
@@ -120,7 +119,7 @@ private fun RemoteViewsAction.getRemoteCollectItemsLegacy(field: Field): RemoteC
 }
 
 @RequiresApi(Build.VERSION_CODES.S)
-private fun RemoteViewsAction.getRemoteCollectItemsFuture(field: Field): RemoteCollectionItems {
+private fun Any.getRemoteCollectItemsFuture(field: Field): RemoteCollectionItems {
     return field.let {
         it.isAccessible = true
         val future = it.get(this) as CompletableFuture<RemoteCollectionItems>
@@ -128,14 +127,14 @@ private fun RemoteViewsAction.getRemoteCollectItemsFuture(field: Field): RemoteC
     }
 }
 
-fun RemoteViewsAction.extractOnClickResponse(): Pair<Int, RemoteResponse> {
+fun Any.extractOnClickResponse(): Pair<Int, RemoteResponse> {
     val intent = setOnClickResponseClass.getDeclaredField("mResponse").apply {
         isAccessible = true
     }.get(this) as RemoteResponse
     return Pair(getId(), intent)
 }
 
-var RemoteViewsAction.reflectionActionValue: Any?
+var Any.reflectionActionValue: Any?
     get() = reflectionActionValueField.get(this)
     set(value) = reflectionActionValueField.set(this, value)
 

--- a/app/src/main/res/layout/item_expanded_remoteviews.xml
+++ b/app/src/main/res/layout/item_expanded_remoteviews.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -7,19 +7,12 @@
     android:paddingEnd="@dimen/margin_8"
     android:layout_marginBottom="@dimen/margin_8">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.kieronquinn.app.smartspacer.ui.views.RoundedCornersEnforcingLinearLayout
+        android:id="@+id/item_expanded_remoteviews_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-        <com.kieronquinn.app.smartspacer.ui.views.RoundedCornersEnforcingLinearLayout
-            android:id="@+id/item_expanded_remoteviews_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="center"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintHeight_max="@dimen/expanded_smartspace_remoteviews_max_height"/>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</androidx.core.widget.NestedScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_expanded_widget.xml
+++ b/app/src/main/res/layout/item_expanded_widget.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/item_expanded_widget_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/margin_8"
@@ -8,53 +9,46 @@
     android:paddingStart="@dimen/margin_8"
     android:paddingEnd="@dimen/margin_8">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/item_expanded_widget_root"
+    <FrameLayout
+        android:id="@+id/item_expanded_widget_container"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/item_expanded_widget_configure"
+        style="@style/Widget.Material3.Button"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="96dp"
+        android:layout_marginStart="@dimen/margin_8"
+        android:layout_marginEnd="@dimen/margin_8"
+        android:background="@drawable/background_widget_expanded"
+        android:text="@string/expanded_widget_configure"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium.Smartspacer"
+        android:textColor="?android:textColorPrimary"
+        app:backgroundTint="@color/black"
+        app:cornerRadius="@dimen/margin_16"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <FrameLayout
-            android:id="@+id/item_expanded_widget_container"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:gravity="center"
-            android:orientation="vertical"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <Space
+        android:id="@+id/item_expanded_widget_configure_space"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_8"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/item_expanded_widget_configure" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/item_expanded_widget_configure"
-            style="@style/Widget.Material3.Button"
-            android:layout_width="match_parent"
-            android:layout_height="96dp"
-            android:layout_marginStart="@dimen/margin_8"
-            android:layout_marginEnd="@dimen/margin_8"
-            android:background="@drawable/background_widget_expanded"
-            android:text="@string/expanded_widget_configure"
-            android:textAppearance="@style/TextAppearance.AppCompat.Medium.Smartspacer"
-            android:textColor="?android:textColorPrimary"
-            app:backgroundTint="@color/black"
-            app:cornerRadius="@dimen/margin_16"
-            app:layout_constraintTop_toTopOf="parent" />
+    <View
+        android:id="@+id/item_expanded_widget_drag_layer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <Space
-            android:id="@+id/item_expanded_widget_configure_space"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/margin_8"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/item_expanded_widget_configure" />
-
-        <View
-            android:id="@+id/item_expanded_widget_drag_layer"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:clickable="true"
-            android:focusable="true"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</androidx.core.widget.NestedScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph_expanded.xml
+++ b/app/src/main/res/navigation/nav_graph_expanded.xml
@@ -37,5 +37,8 @@
         <argument
             android:name="app_widget_id"
             app:argType="integer" />
+        <argument
+            android:name="can_reconfigure"
+            app:argType="boolean"/>
     </dialog>
 </navigation>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -3,8 +3,6 @@
     <string-array name="xposed_scope">
         <!-- Pixel Launcher -->
         <item>com.google.android.apps.nexuslauncher</item>
-        <!-- Nova Launcher -->
-        <item>com.teslacoilsw.launcherclientproxy</item>
         <!-- Lawnchair -->
         <item>app.lawnchair</item>
         <item>app.lawnchair.debug</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -756,6 +756,8 @@
     <string name="expanded_custom_widget_options_span_x_content">The width for this widget, in cells</string>
     <string name="expanded_custom_widget_options_span_y_title">Height</string>
     <string name="expanded_custom_widget_options_span_y_content">The height for this widget, in rows</string>
+    <string name="expanded_custom_widget_options_reconfigure_title">Reconfigure</string>
+    <string name="expanded_custom_widget_options_reconfigure_content">Change settings for this widget in its app</string>
     <string name="expanded_custom_widget_options_show_when_locked_title">Show when locked</string>
     <string name="expanded_custom_widget_options_show_when_locked_content">Show this widget in Expanded Smartspace when the device is locked</string>
     <string name="add_widget_empty_label">No Widgets found</string>

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ buildscript {
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.2' apply false
-    id 'com.android.library' version '8.1.2' apply false
+    id 'com.android.application' version '8.2.0' apply false
+    id 'com.android.library' version '8.2.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.10' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
     id 'dev.rikka.tools.refine' version "$refine_version" apply false

--- a/sdk-core/build.gradle
+++ b/sdk-core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.kieronquinn.smartspacer", "sdk-core", "1.0.2")
+    coordinates("com.kieronquinn.smartspacer", "sdk-core", "1.0.3")
 
     pom {
         name = "Smartspacer Core SDK"

--- a/sdk-core/src/main/java/com/kieronquinn/app/smartspacer/sdk/model/expanded/ExpandedState.kt
+++ b/sdk-core/src/main/java/com/kieronquinn/app/smartspacer/sdk/model/expanded/ExpandedState.kt
@@ -65,10 +65,6 @@ data class ExpandedState(
      *  displaying while locked, setting only [view] will apply to both. To display only when
      *  unlocked, set [unlocked] and leave [locked] and [view] as null (the same can be done for
      *  [locked] to set only the locked RemoteViews.
-     *
-     *  Please note that, for performance and UX reasons, the height of the RemoteViews is clipped
-     *  at `300dp`. Your RemoteViews will be wrapped in a scrollable View to handle this, if
-     *  required (Smartspacer automatically handles nested scrolling)
      */
     @Parcelize
     data class RemoteViews(

--- a/sdk-plugin/build.gradle
+++ b/sdk-plugin/build.gradle
@@ -37,11 +37,11 @@ android {
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.12.0'
-    api('com.kieronquinn.smartspacer:sdk-core:1.0.2')
+    api('com.kieronquinn.smartspacer:sdk-core:1.0.3')
 }
 
 mavenPublishing {
-    coordinates("com.kieronquinn.smartspacer", "sdk-plugin", "1.0.2")
+    coordinates("com.kieronquinn.smartspacer", "sdk-plugin", "1.0.3")
 
     pom {
         name = "Smartspacer Plugin SDK"

--- a/sdk-plugin/src/main/java/com/kieronquinn/app/smartspacer/sdk/provider/BaseProvider.kt
+++ b/sdk-plugin/src/main/java/com/kieronquinn/app/smartspacer/sdk/provider/BaseProvider.kt
@@ -10,7 +10,6 @@ import android.os.Bundle
 import androidx.annotation.RestrictTo
 import com.kieronquinn.app.smartspacer.sdk.SmartspacerConstants
 
-@RestrictTo(RestrictTo.Scope.LIBRARY)
 abstract class BaseProvider: ContentProvider() {
 
     protected fun verifySecurity() {

--- a/sdk-sample/build.gradle
+++ b/sdk-sample/build.gradle
@@ -34,7 +34,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation "androidx.fragment:fragment-ktx:1.6.1"
+    implementation "androidx.fragment:fragment-ktx:1.6.2"
     implementation "androidx.lifecycle:lifecycle-service:2.6.2"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"


### PR DESCRIPTION
- Added option to reconfigure widgets on expanded which support it
- Removed scrolling & max height of expanded remoteviews since it was pretty much pointless and if abused the user can just remove the Target or disable the remoteviews
- Fixed a widget-related crash in an upcoming version of Android
- Removed Nova Launcher's bridge from the suggested Xposed apps
- Fixed tests
- Updated dependencies