### PR TITLE
Release/1.3.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ plugins {
 
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
-def tagName = '1.3.2'
-def tagCode = 132
+def tagName = '1.3.3'
+def tagCode = 133
 
 android {
     compileSdk 34

--- a/app/src/androidTest/java/com/kieronquinn/app/smartspacer/repositories/SystemSmartspaceRepositoryTests.kt
+++ b/app/src/androidTest/java/com/kieronquinn/app/smartspacer/repositories/SystemSmartspaceRepositoryTests.kt
@@ -15,7 +15,6 @@ import com.kieronquinn.app.smartspacer.service.SmartspacerSmartspaceService
 import com.kieronquinn.app.smartspacer.test.BaseTest
 import com.kieronquinn.app.smartspacer.utils.extensions.Icon_createEmptyIcon
 import com.kieronquinn.app.smartspacer.utils.mockSmartspacerSetting
-import com.kieronquinn.app.smartspacer.utils.randomInt
 import com.kieronquinn.app.smartspacer.utils.randomString
 import io.mockk.coEvery
 import io.mockk.every
@@ -73,7 +72,7 @@ class SystemSmartspaceRepositoryTests: BaseTest<SystemSmartspaceRepository>() {
         sut.setService()
         verify(exactly = 1) {
             shizukuService.setSmartspaceService(
-                SmartspacerSmartspaceService.COMPONENT, any(), true
+                SmartspacerSmartspaceService.COMPONENT, any(), true, any()
             )
         }
     }
@@ -94,7 +93,7 @@ class SystemSmartspaceRepositoryTests: BaseTest<SystemSmartspaceRepository>() {
         sut.notifyServiceRunning()
         assertTrue(sut.serviceRunning.value)
         verify(exactly = 1) {
-            shizukuService.setSmartspaceService(component, any(), false)
+            shizukuService.setSmartspaceService(component, any(), false, any())
         }
         every {
             resourcesMock.getIdentifier(
@@ -103,7 +102,7 @@ class SystemSmartspaceRepositoryTests: BaseTest<SystemSmartspaceRepository>() {
         } returns 0
         sut.resetService(false, killSystemUi = true)
         verify(exactly = 1) {
-            shizukuService.clearSmartspaceService(any(), true)
+            shizukuService.clearSmartspaceService(any(), true, any())
         }
         assertFalse(sut.serviceRunning.value)
     }
@@ -249,7 +248,7 @@ class SystemSmartspaceRepositoryTests: BaseTest<SystemSmartspaceRepository>() {
         } returns listOf(
             CompatibilityReport(
                 randomString(),
-                randomInt(),
+                randomString(),
                 listOf(CompatibilityRepository.Compatibility(Feature.BASIC, true))
             )
         )

--- a/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/complications/edit/ComplicationEditViewModelTests.kt
+++ b/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/complications/edit/ComplicationEditViewModelTests.kt
@@ -21,7 +21,6 @@ import com.kieronquinn.app.smartspacer.model.database.Requirement
 import com.kieronquinn.app.smartspacer.model.database.Widget.Type
 import com.kieronquinn.app.smartspacer.model.smartspace.Widget
 import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository
-import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository.Companion.PACKAGE_PIXEL_LAUNCHER
 import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository.CompatibilityReport
 import com.kieronquinn.app.smartspacer.repositories.DatabaseRepository
 import com.kieronquinn.app.smartspacer.repositories.OemSmartspacerRepository
@@ -31,6 +30,7 @@ import com.kieronquinn.app.smartspacer.repositories.WidgetRepository
 import com.kieronquinn.app.smartspacer.sdk.provider.SmartspacerComplicationProvider
 import com.kieronquinn.app.smartspacer.test.BaseTest
 import com.kieronquinn.app.smartspacer.ui.screens.complications.edit.ComplicationEditViewModel.State
+import com.kieronquinn.app.smartspacer.utils.PACKAGE_PIXEL_LAUNCHER
 import com.kieronquinn.app.smartspacer.utils.mockSmartspacerSetting
 import com.kieronquinn.app.smartspacer.utils.randomBoolean
 import com.kieronquinn.app.smartspacer.utils.randomInt
@@ -75,8 +75,8 @@ class ComplicationEditViewModelTests: BaseTest<ComplicationEditViewModel>() {
         }
 
         private val mockCompatibilityReports = listOf(
-            CompatibilityReport(PACKAGE_PIXEL_LAUNCHER, 0, emptyList()),
-            CompatibilityReport(PACKAGE_KEYGUARD, 0, emptyList())
+            CompatibilityReport(PACKAGE_PIXEL_LAUNCHER, "Pixel Launcher", emptyList()),
+            CompatibilityReport(PACKAGE_KEYGUARD, "SystemUI", emptyList())
         )
 
         private val mockCompatibleApps = listOf(

--- a/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/enhancedmode/EnhancedModeViewModelTests.kt
+++ b/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/enhancedmode/EnhancedModeViewModelTests.kt
@@ -25,7 +25,7 @@ class EnhancedModeViewModelTests: BaseTest<EnhancedModeViewModel>() {
     private val compatibilityRepositoryMock = mock<CompatibilityRepository> {
         coEvery { getCompatibilityState(true) } returns CompatibilityState(
             systemSupported = true,
-            pixelLauncherSupported = true,
+            anyLauncherSupported = true,
             lockscreenSupported = true,
             appPredictionSupported = true,
             oemSmartspaceSupported = true

--- a/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/native/NativeModeViewModelTests.kt
+++ b/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/native/NativeModeViewModelTests.kt
@@ -16,7 +16,6 @@ import com.kieronquinn.app.smartspacer.test.BaseTest
 import com.kieronquinn.app.smartspacer.ui.screens.native.NativeModeViewModel.State
 import com.kieronquinn.app.smartspacer.utils.assertOutputs
 import com.kieronquinn.app.smartspacer.utils.mockSmartspacerSetting
-import com.kieronquinn.app.smartspacer.utils.randomInt
 import com.kieronquinn.app.smartspacer.utils.randomString
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -41,7 +40,7 @@ class NativeModeViewModelTests: BaseTest<NativeModeViewModel>() {
 
     private val compatibilityRepositoryMock = mock<CompatibilityRepository> {
         coEvery { getCompatibilityReports() } returns listOf(
-            CompatibilityReport(randomString(), randomInt(), emptyList())
+            CompatibilityReport(randomString(), randomString(), emptyList())
         )
     }
 

--- a/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/targets/edit/TargetEditViewModelTests.kt
+++ b/app/src/androidTest/java/com/kieronquinn/app/smartspacer/ui/screens/targets/edit/TargetEditViewModelTests.kt
@@ -21,7 +21,6 @@ import com.kieronquinn.app.smartspacer.model.database.Target
 import com.kieronquinn.app.smartspacer.model.database.Widget.Type
 import com.kieronquinn.app.smartspacer.model.smartspace.Widget
 import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository
-import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository.Companion.PACKAGE_PIXEL_LAUNCHER
 import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository.CompatibilityReport
 import com.kieronquinn.app.smartspacer.repositories.DatabaseRepository
 import com.kieronquinn.app.smartspacer.repositories.ExpandedRepository
@@ -32,6 +31,7 @@ import com.kieronquinn.app.smartspacer.repositories.WidgetRepository
 import com.kieronquinn.app.smartspacer.sdk.provider.SmartspacerTargetProvider
 import com.kieronquinn.app.smartspacer.test.BaseTest
 import com.kieronquinn.app.smartspacer.ui.screens.targets.edit.TargetEditViewModel.State
+import com.kieronquinn.app.smartspacer.utils.PACKAGE_PIXEL_LAUNCHER
 import com.kieronquinn.app.smartspacer.utils.mockSmartspacerSetting
 import com.kieronquinn.app.smartspacer.utils.randomBoolean
 import com.kieronquinn.app.smartspacer.utils.randomInt
@@ -78,8 +78,8 @@ class TargetEditViewModelTests: BaseTest<TargetEditViewModel>() {
         }
 
         private val mockCompatibilityReports = listOf(
-            CompatibilityReport(PACKAGE_PIXEL_LAUNCHER, 0, emptyList()),
-            CompatibilityReport(PACKAGE_KEYGUARD, 0, emptyList())
+            CompatibilityReport(PACKAGE_PIXEL_LAUNCHER, randomString(), emptyList()),
+            CompatibilityReport(PACKAGE_KEYGUARD, randomString(), emptyList())
         )
 
         private val mockCompatibleApps = listOf(

--- a/app/src/androidTest/java/com/kieronquinn/app/smartspacer/utils/TestConstants.kt
+++ b/app/src/androidTest/java/com/kieronquinn/app/smartspacer/utils/TestConstants.kt
@@ -1,0 +1,3 @@
+package com.kieronquinn.app.smartspacer.utils
+
+const val PACKAGE_PIXEL_LAUNCHER = "com.google.android.apps.nexuslauncher"

--- a/app/src/main/aidl/com/kieronquinn/app/smartspacer/ISmartspacerShizukuService.aidl
+++ b/app/src/main/aidl/com/kieronquinn/app/smartspacer/ISmartspacerShizukuService.aidl
@@ -14,8 +14,8 @@ interface ISmartspacerShizukuService {
 
     boolean ping() = 1;
     boolean isRoot() = 2;
-    void setSmartspaceService(in ComponentName component, int userId, boolean killSystemUi) = 3;
-    void clearSmartspaceService(int userId, boolean killSystemUi) = 4;
+    void setSmartspaceService(in ComponentName component, int userId, boolean killSystemUi, in List<String> killPackages) = 3;
+    void clearSmartspaceService(int userId, boolean killSystemUi, in List<String> killPackages) = 4;
     ISmartspaceSession createSmartspaceSession(in SmartspaceConfig config) = 5;
     void destroySmartspaceSession(in SmartspaceSessionId sessionId) = 6;
 

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/Smartspacer.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/Smartspacer.kt
@@ -402,7 +402,7 @@ class Smartspacer: Application(), Configuration.Provider {
         viewModel<DisplayOverOtherAppsPermissionBottomSheetViewModel> { DisplayOverOtherAppsPermissionBottomSheetViewModelImpl(get()) }
         viewModel<WidgetOptionsMenuViewModel> { WidgetOptionsMenuViewModelImpl(get(), get()) }
         viewModel<NativeReconnectViewModel> { NativeReconnectViewModelImpl(get(), get()) }
-        viewModel<DumpSmartspacerViewModel> { DumpSmartspacerViewModelImpl(get()) }
+        viewModel<DumpSmartspacerViewModel> { DumpSmartspacerViewModelImpl(get(), get()) }
     }
 
     override fun attachBaseContext(base: Context) {

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/repositories/SmartspacerSettingsRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/repositories/SmartspacerSettingsRepository.kt
@@ -60,9 +60,7 @@ interface SmartspacerSettingsRepository {
     val hasUsedNativeMode: SmartspacerSetting<Boolean>
 
     /**
-     *  The count to limit the number of native targets sent to system Smartspace Sessions. This
-     *  is required due to oneway spam between the Pixel Launcher and SystemUI causing crashes,
-     *  limiting to one target fixes this to the detriment of convenience.
+     *  The count to limit the number of native targets sent to system Smartspace Sessions.
      */
     @IgnoreInBackup
     val nativeTargetCountLimit: SmartspacerSetting<TargetCountLimit>

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/complications/edit/ComplicationEditViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/complications/edit/ComplicationEditViewModel.kt
@@ -5,12 +5,10 @@ import android.content.Context
 import android.content.pm.ActivityInfo
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.Icon
-import android.util.Log
 import com.kieronquinn.app.smartspacer.Smartspacer.Companion.PACKAGE_KEYGUARD
 import com.kieronquinn.app.smartspacer.components.navigation.ContainerNavigation
 import com.kieronquinn.app.smartspacer.model.database.Widget
 import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository
-import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository.Companion.PACKAGE_PIXEL_LAUNCHER
 import com.kieronquinn.app.smartspacer.repositories.DatabaseRepository
 import com.kieronquinn.app.smartspacer.repositories.OemSmartspacerRepository
 import com.kieronquinn.app.smartspacer.repositories.SmartspacerSettingsRepository
@@ -108,9 +106,9 @@ class ComplicationEditViewModelImpl(
         val nativePreviouslyUsed = settingsRepository.enhancedMode.get()
                 && settingsRepository.hasUsedNativeMode.get()
         val reports = compatibilityRepository.getCompatibilityReports()
-        val isUsingPixelLauncher = context.getDefaultLauncher() == PACKAGE_PIXEL_LAUNCHER
-        val nativeHomeAvailable = nativePreviouslyUsed && isUsingPixelLauncher &&
-                reports.any { packageName -> packageName.packageName == PACKAGE_PIXEL_LAUNCHER }
+        val defaultLauncher = context.getDefaultLauncher()
+        val nativeHomeAvailable = nativePreviouslyUsed &&
+                reports.any { packageName -> packageName.packageName == defaultLauncher }
         val nativeLockAvailable = nativePreviouslyUsed && reports.any { packageName ->
             packageName.packageName == PACKAGE_KEYGUARD
         }

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/configuration/accessibility/ConfigurationAccessibilityEnableFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/configuration/accessibility/ConfigurationAccessibilityEnableFragment.kt
@@ -18,9 +18,9 @@ import com.kieronquinn.app.smartspacer.service.SmartspacerAccessibiltyService
 import com.kieronquinn.app.smartspacer.ui.base.BoundFragment
 import com.kieronquinn.app.smartspacer.utils.extensions.applyBackgroundTint
 import com.kieronquinn.app.smartspacer.utils.extensions.getAccessibilityIntent
-import com.kieronquinn.app.smartspacer.utils.extensions.isAtLeastU
 import com.kieronquinn.app.smartspacer.utils.extensions.onClicked
 import com.kieronquinn.app.smartspacer.utils.extensions.onNavigationIconClicked
+import com.kieronquinn.app.smartspacer.utils.extensions.shouldShowRequireSideload
 import com.kieronquinn.app.smartspacer.utils.extensions.showAppInfo
 import com.kieronquinn.app.smartspacer.utils.extensions.wasInstalledWithSession
 import com.kieronquinn.app.smartspacer.utils.extensions.whenResumed
@@ -77,7 +77,7 @@ class ConfigurationAccessibilityEnableFragment: BoundFragment<FragmentConfigurat
 
     @SuppressLint("UnsafeOptInUsageError")
     private fun setupWarningCard() {
-        val shouldShow = isAtLeastU() && !requireContext().wasInstalledWithSession()
+        val shouldShow = requireContext().shouldShowRequireSideload()
         binding.configurationAccessibilityWarning.applyBackgroundTint(monet)
         binding.configurationAccessibilityWarning.isVisible = shouldShow
         binding.configurationAccessibilityWarningButton.isVisible = settings.enhancedMode.getSync()

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/enhancedmode/EnhancedModeFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/enhancedmode/EnhancedModeFragment.kt
@@ -146,8 +146,8 @@ class EnhancedModeFragment: BoundFragment<FragmentEnhancedModeBinding>(FragmentE
         if(systemSupported){
             appendLine(getString(R.string.enhanced_mode_enable_content_system))
         }
-        if(pixelLauncherSupported){
-            appendLine(getString(R.string.enhanced_mode_enable_content_native_pixel_launcher))
+        if(anyLauncherSupported){
+            appendLine(getString(R.string.enhanced_mode_enable_content_native_launcher))
         }
         if(lockscreenSupported){
             appendLine(getString(R.string.enhanced_mode_enable_content_native_systemui))

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/settings/home/ExpandedHomeOpenModeSettingsFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/settings/home/ExpandedHomeOpenModeSettingsFragment.kt
@@ -1,6 +1,9 @@
 package com.kieronquinn.app.smartspacer.ui.screens.expanded.settings.home
 
+import androidx.core.content.ContextCompat
 import androidx.navigation.fragment.navArgs
+import com.kieronquinn.app.smartspacer.R
+import com.kieronquinn.app.smartspacer.model.settings.GenericSettingsItem
 import com.kieronquinn.app.smartspacer.repositories.SmartspacerSettingsRepository.ExpandedOpenMode
 import com.kieronquinn.app.smartspacer.ui.base.BackAvailable
 import com.kieronquinn.app.smartspacer.ui.base.HideBottomNavigation
@@ -12,6 +15,15 @@ class ExpandedHomeOpenModeSettingsFragment: BaseRadioSettingsFragment<ExpandedOp
     private val args by navArgs<ExpandedHomeOpenModeSettingsFragmentArgs>()
 
     override val viewModel by viewModel<ExpandedHomeOpenModeSettingsViewModel>()
+
+    override val header by lazy {
+        listOf(
+            GenericSettingsItem.Card(
+                ContextCompat.getDrawable(requireContext(), R.drawable.ic_info),
+                getText(R.string.expanded_settings_date_info)
+            )
+        )
+    }
 
     override fun getSettingTitle(setting: ExpandedOpenMode): CharSequence {
         return getString(setting.label)

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/settings/lock/ExpandedLockOpenModeSettingsFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/settings/lock/ExpandedLockOpenModeSettingsFragment.kt
@@ -1,6 +1,9 @@
 package com.kieronquinn.app.smartspacer.ui.screens.expanded.settings.lock
 
+import androidx.core.content.ContextCompat
 import androidx.navigation.fragment.navArgs
+import com.kieronquinn.app.smartspacer.R
+import com.kieronquinn.app.smartspacer.model.settings.GenericSettingsItem
 import com.kieronquinn.app.smartspacer.repositories.SmartspacerSettingsRepository.ExpandedOpenMode
 import com.kieronquinn.app.smartspacer.ui.base.BackAvailable
 import com.kieronquinn.app.smartspacer.ui.base.HideBottomNavigation
@@ -12,6 +15,15 @@ class ExpandedLockOpenModeSettingsFragment: BaseRadioSettingsFragment<ExpandedOp
     private val args by navArgs<ExpandedLockOpenModeSettingsFragmentArgs>()
 
     override val viewModel by viewModel<ExpandedLockOpenModeSettingsViewModel>()
+
+    override val header by lazy {
+        listOf(
+            GenericSettingsItem.Card(
+                ContextCompat.getDrawable(requireContext(), R.drawable.ic_info),
+                getText(R.string.expanded_settings_date_info)
+            )
+        )
+    }
 
     override fun getSettingTitle(setting: ExpandedOpenMode): CharSequence {
         return getString(setting.label)

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/native/NativeModeAdapter.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/native/NativeModeAdapter.kt
@@ -32,7 +32,7 @@ class NativeModeAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) = with(holder.binding) {
         val item = items[position]
-        nativeCompatibilityAppName.setText(item.labelRes)
+        nativeCompatibilityAppName.text = item.label
         glide.load(PackageIcon(item.packageName))
             .placeholder(nativeCompatibilityIcon.drawable)
             .into(nativeCompatibilityIcon)

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/native/NativeModeFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/native/NativeModeFragment.kt
@@ -238,13 +238,13 @@ class NativeModeFragment: BoundFragment<FragmentNativeBinding>(FragmentNativeBin
 
     private fun List<CompatibilityReport>.getContent(): String {
         val format = if(size == 1){
-            getString(first().labelRes)
+            first().label
         }else{
             val joiner = getString(R.string.native_switch_content_joiner)
             val items = subList(0, size - 1).joinToString("$joiner ") {
-                getString(it.labelRes)
+                it.label
             }
-            val last = getString(last().labelRes)
+            val last = last().label
             getString(R.string.native_switch_content_many, items, last)
         }
         return getString(R.string.native_switch_content, format)

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/targets/edit/TargetEditViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/targets/edit/TargetEditViewModel.kt
@@ -10,7 +10,6 @@ import com.kieronquinn.app.smartspacer.components.navigation.ContainerNavigation
 import com.kieronquinn.app.smartspacer.model.database.Target
 import com.kieronquinn.app.smartspacer.model.database.Widget
 import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository
-import com.kieronquinn.app.smartspacer.repositories.CompatibilityRepository.Companion.PACKAGE_PIXEL_LAUNCHER
 import com.kieronquinn.app.smartspacer.repositories.DatabaseRepository
 import com.kieronquinn.app.smartspacer.repositories.ExpandedRepository
 import com.kieronquinn.app.smartspacer.repositories.OemSmartspacerRepository
@@ -117,9 +116,9 @@ class TargetEditViewModelImpl(
         val expandedMode = settingsRepository.expandedModeEnabled.get()
         val nativePreviouslyUsed = enhancedMode && settingsRepository.hasUsedNativeMode.get()
         val reports = compatibilityRepository.getCompatibilityReports()
-        val isUsingPixelLauncher = context.getDefaultLauncher() == PACKAGE_PIXEL_LAUNCHER
-        val nativeHomeAvailable = nativePreviouslyUsed && isUsingPixelLauncher &&
-                reports.any { packageName -> packageName.packageName == PACKAGE_PIXEL_LAUNCHER }
+        val defaultLauncher = context.getDefaultLauncher()
+        val nativeHomeAvailable = nativePreviouslyUsed &&
+                reports.any { packageName -> packageName.packageName == defaultLauncher }
         val nativeLockAvailable = nativePreviouslyUsed && reports.any { packageName ->
             packageName.packageName == PACKAGE_KEYGUARD
         }

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+Context.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+Context.kt
@@ -336,6 +336,18 @@ fun Context.getDefaultLauncher(): String? {
     )?.activityInfo?.packageName
 }
 
+fun Context.getAllLaunchers(): List<String> {
+    val homeIntent = Intent(Intent.ACTION_MAIN).apply {
+        addCategory(Intent.CATEGORY_HOME)
+    }
+    return packageManager.queryIntentActivitiesCompat(homeIntent).map {
+        it.activityInfo.packageName
+    }.filterNot {
+        //Smartspacer is registered as a launcher but we never want to interact with ourselves
+        it == BuildConfig.APPLICATION_ID
+    }
+}
+
 fun Context.dip(value: Int): Int = resources.dip(value)
 
 fun Context.getSystemHideSensitive(): HideSensitive {

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Nativer Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Sperrbildschirm</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Los geht\'s</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warnung:</b> Auf einigen Geräten mit bestimmten Kombinationen von Zielen kann es bei aktivierten Optionen höher als \"Single Page\" zu periodischen SystemUI- und Pixel Launcher-Abstürzen kommen.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Permite a Smartspacer interactuar e integrarse con funciones del sistema</string>
     <string name="settings_enhanced_content_unsupported">Esta opción no es compatible con tu dispositivo</string>
     <string name="settings_native_smartspace_settings_title">Smartspace nativo</string>
-    <string name="settings_native_smartspace_settings_content">Opciones para Smartspacer mostradas en el Smartspace dentro de Pixel Launcher y en la pantalla de bloqueo</string>
     <string name="settings_native_smartspace_settings_content_incompatible">Esta opción no es compatible con tu dispositivo</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">Esta opción requiere Modo mejorado</string>
     <string name="settings_targets_complications">Objetivos y complicaciones</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Pantalla de bloqueo</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Comenzar</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requiere Shizuku o Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>El modo mejorado le permite a Smartspacer:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrar en el Smartspace de la pantalla de bloqueo</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrar en el Smartspace en Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Mostrar objetivos y complicaciones del Smartspace del sistema en Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Límite de páginas</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Permet à Smartspacer d\'interagir et de s\'intégrer aux fonctionnalités système</string>
     <string name="settings_enhanced_content_unsupported">Cette option est incompatible avec votre appareil</string>
     <string name="settings_native_smartspace_settings_title">Smartspace natif</string>
-    <string name="settings_native_smartspace_settings_content">Options pour Smartspacer dans le Pixel Launcher et sur l\'écran de verrouillage</string>
     <string name="settings_native_smartspace_settings_content_incompatible">Cette option est incompatible avec votre appareil</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">Cette option nécessite l\'activation du mode amélioré</string>
     <string name="settings_targets_complications">Cibles et complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Écran de verrouillage</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Commencer</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requiert Shizuku ou Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Le mode amélioré permet à Smartspacer de :</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• S\'intégrer à Smartspace sur l\'écran de verrouillage</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• S\'intégrer à Smartspace dans le Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• S\'intégrer au Smartspace OEM (si disponible)</string>
     <string name="enhanced_mode_enable_content_system">• Afficher les cibles et les complications du Smartspace système dans Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Utiliser les suggestions d\'application du système en tant que condition</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Smartspace natif</string>
     <string name="native_mode_settings_target_limit_title">Limite de pages</string>
     <string name="native_mode_settings_target_limit_content">Nombre maximum de pages de cibles et de complications à afficher : %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Attention :</b> sur certains appareils et avec certaines cibles activées, vous pourriez rencontrer des plantages périodiques de l\'interface système et du Pixel Launcher si vous sélectionnez une option autre qu\'Une seule page.</string>
     <string name="native_mode_settings_target_limit_one">Une seule page</string>
     <string name="native_mode_settings_target_limit_one_content">Afficher uniquement la première page</string>
     <string name="native_mode_settings_target_limit_automatic">Laisser l\'écran de verrouillage ou le lanceur d\'applications décider</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Permite que o Smartspacer interaja e se integre com recursos do sistema</string>
     <string name="settings_enhanced_content_unsupported">Esta opção não é compatível com o seu dispositivo</string>
     <string name="settings_native_smartspace_settings_title">Smartspace Nativo</string>
-    <string name="settings_native_smartspace_settings_content">Opções para o Smartspacer ser exibido no Smartspace no Pixel Launcher e na Tela de bloqueio</string>
     <string name="settings_native_smartspace_settings_content_incompatible">Esta opção não é compatível com o seu dispositivo</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">Esta opção requer o Modo Avançado</string>
     <string name="settings_targets_complications">Destaques &amp; complementos</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requer Shizuku ou Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>O Modo Avançado permite que o Smartspacer:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrar o Smartspace na tela de bloqueio</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrar o Smartspace no Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrar com Smartspace OEM (se disponível)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Позволяет Smartspacer взаимодействовать с системными возможностями</string>
     <string name="settings_enhanced_content_unsupported">Эта настройка несовместима с вашим устройством</string>
     <string name="settings_native_smartspace_settings_title">Нативный режим</string>
-    <string name="settings_native_smartspace_settings_content">Настройки для показа Smartspacer в Pixel Launcher и на экране блокировки</string>
     <string name="settings_native_smartspace_settings_content_incompatible">Эта настройка несовместима с вашим устройством</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">Эта настройка требует Усиленный режим</string>
     <string name="settings_targets_complications">Цели и Дополнения</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Экран блокировки</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Начать</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Требуется Shizuku или Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Усиленный режим позволяет Smartspacer:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Интегрироваться в Smartspace на экране блокировки</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Интегрироваться в Smartspace в Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Интегрироваться в OEM Smartspace (если доступно)</string>
     <string name="enhanced_mode_enable_content_system">• Показывать системные Цели и Дополнения в Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Использовать системные Подсказки Приложений как Требование</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Нативный режим</string>
     <string name="native_mode_settings_target_limit_title">Лимит страниц</string>
     <string name="native_mode_settings_target_limit_content">Максимальное количество страниц Целей и Дополнений: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Внимание</b>: на некоторых устройствах, с некоторыми комбинациями Целей, вы можете испытывать сбои Интерфейса Системы и Pixel Launcher при настройках, больших, чем одна страница.</string>
     <string name="native_mode_settings_target_limit_one">Одна страница</string>
     <string name="native_mode_settings_target_limit_one_content">Ограничить Smartspace только первой страницей</string>
     <string name="native_mode_settings_target_limit_automatic">Позволить решать экрану блокировки/лаунчеру</string>

--- a/app/src/main/res/values-sr-rSP/strings.xml
+++ b/app/src/main/res/values-sr-rSP/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">Allows Smartspacer to interact and integrate with system features</string>
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
     <string name="settings_targets_complications">Targets &amp; Complications</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">Get Started</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">允许 Smartspacer 与系统功能交互和集成</string>
     <string name="settings_enhanced_content_unsupported">此选项与你的设备不兼容</string>
     <string name="settings_native_smartspace_settings_title">本机 Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">让 Smartspacer 在 Pixel 启动器和锁屏的 Smartspace 中显示的选项</string>
     <string name="settings_native_smartspace_settings_content_incompatible">该选项与你的设备不兼容</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">该选项依赖增强模式</string>
     <string name="settings_targets_complications">对象 &amp; 附件</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">锁屏</string>
-    <string name="compatibility_label_pixel_launcher">Pixel 启动器</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">快速上手</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">需要 Shizuku 或 Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>在增强模式下 Smartspacer 可以：</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• 与锁屏的 Smartspace 集成</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• 与 Pixel 启动器中的 Smartspace 集成</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• 与 OEM 的 Smartspace 集成（如果可用）</string>
     <string name="enhanced_mode_enable_content_system">• 在 Smartspacer 中显示系统的 Smartspace 对象与附件</string>
     <string name="enhanced_mode_enable_content_app_prediction">• 使用系统应用预测作为触发条件</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">本机 Smartspace</string>
     <string name="native_mode_settings_target_limit_title">页面限制</string>
     <string name="native_mode_settings_target_limit_content">用于展示对象和附件的最大页面数量：%1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>警告：</b>页面选项设置超过单页时，特定组合的对象在某些设备上可能会造成短暂的系统界面和 Pixel 启动器崩溃。</string>
     <string name="native_mode_settings_target_limit_one">单页</string>
     <string name="native_mode_settings_target_limit_one_content">限制 Smartspace 为只显示第一页</string>
     <string name="native_mode_settings_target_limit_automatic">由锁屏/启动器决定</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -365,7 +365,6 @@
     <string name="settings_enhanced_content">允許 Smartspacer 與系統功能互動及整合</string>
     <string name="settings_enhanced_content_unsupported">您的裝置不支援此選項</string>
     <string name="settings_native_smartspace_settings_title">原生 Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">在 Pixel 啟動器及鎖定畫面中顯示 Smartspacer 的選項</string>
     <string name="settings_native_smartspace_settings_content_incompatible">您的裝置不支援此選項</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">此選項需要啟用增強模式</string>
     <string name="settings_targets_complications">目標 &amp; 複雜性</string>
@@ -422,7 +421,6 @@
     <string name="compatibility_template_sub_list_title">@string/compatibility_feature_shopping_list_title</string>
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
     <string name="compatibility_label_systemui">鎖定螢幕</string>
-    <string name="compatibility_label_pixel_launcher">Pixel 啟動器</string>
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
     <string name="landing_button_get_started">開始使用</string>
@@ -513,7 +511,6 @@
     <string name="enhanced_mode_enable_subtitle">需要 Shizuku 或 Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>加強模式允許 Smartspacer 做到：</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• 整合至鎖定螢幕上的 Smartspace</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• 整合至 Pixel 啟動器中的 Smartspace</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• 整合至 OEM Smartspace（如果可用的話）</string>
     <string name="enhanced_mode_enable_content_system">• 在 Smartspacer 中顯示系統 Smartspace 目標和複雜功能</string>
     <string name="enhanced_mode_enable_content_app_prediction">• 使用系統應用預測作為需求</string>
@@ -577,7 +574,6 @@
     <string name="native_mode_settings_title">本機 Smartspace</string>
     <string name="native_mode_settings_target_limit_title">頁面限制</string>
     <string name="native_mode_settings_target_limit_content">顯示的目標和複雜功能的最大頁數：%1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>警告：</b>在某些裝置上，如果啟用了超過單頁的選項，結合某些目標時，可能會經歷 SystemUI 和 Pixel Launcher 的週期性崩潰。</string>
     <string name="native_mode_settings_target_limit_one">單一頁面</string>
     <string name="native_mode_settings_target_limit_one_content">限制 Smartspace 只顯示第一頁</string>
     <string name="native_mode_settings_target_limit_automatic">讓鎖定螢幕／啟動器決定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,7 +405,7 @@
     <string name="settings_enhanced_content_unsupported">This option is not compatible with your device</string>
 
     <string name="settings_native_smartspace_settings_title">Native Smartspace</string>
-    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within the Pixel Launcher and on the Lock Screen</string>
+    <string name="settings_native_smartspace_settings_content">Options for Smartspacer showing in the Smartspace within compatible launchers and on the Lock Screen</string>
     <string name="settings_native_smartspace_settings_content_incompatible">This option is not compatible with your device</string>
     <string name="settings_native_smartspace_settings_content_incompatible_enhanced">This option requires Enhanced Mode</string>
 
@@ -468,7 +468,6 @@
     <string name="compatibility_template_sub_list_content">@string/compatibility_feature_shopping_list_content</string>
 
     <string name="compatibility_label_systemui">Lock Screen</string>
-    <string name="compatibility_label_pixel_launcher">Pixel Launcher</string>
 
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>
@@ -573,7 +572,7 @@
     <string name="enhanced_mode_enable_subtitle">Requires Shizuku or Sui</string>
     <string name="enhanced_mode_enable_content_header"><b>Enhanced Mode allows Smartspacer to:</b></string>
     <string name="enhanced_mode_enable_content_native_systemui">• Integrate into the Smartspace on the Lock Screen</string>
-    <string name="enhanced_mode_enable_content_native_pixel_launcher">• Integrate into the Smartspace in the Pixel Launcher</string>
+    <string name="enhanced_mode_enable_content_native_launcher">• Integrate into the Smartspace on compatible launchers</string>
     <string name="enhanced_mode_enable_content_oem_smartspace">• Integrate into the OEM Smartspace (if available)</string>
     <string name="enhanced_mode_enable_content_system">• Show System Smartspace Targets and Complications in Smartspacer</string>
     <string name="enhanced_mode_enable_content_app_prediction">• Use system App Predictions as a Requirement</string>
@@ -646,7 +645,7 @@
     <string name="native_mode_settings_title">Native Smartspace</string>
     <string name="native_mode_settings_target_limit_title">Page Limit</string>
     <string name="native_mode_settings_target_limit_content">The maximum number of pages of Targets and Complications to show: %1s</string>
-    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Pixel Launcher crashes with options higher than Single Page enabled.</string>
+    <string name="native_mode_settings_target_limit_warning"><b>Warning:</b> On some devices with some combinations of Targets, you may experience periodic SystemUI and Native Smartspace compatible launcher crashes with options higher than Single Page enabled.</string>
     <string name="native_mode_settings_target_limit_one">Single page</string>
     <string name="native_mode_settings_target_limit_one_content">Limits Smartspace to only show the first page</string>
     <string name="native_mode_settings_target_limit_automatic">Let Lock Screen/Launcher decide</string>
@@ -718,6 +717,7 @@
     <string name="expanded_settings_open_mode_if_has_extras_content">Opens Expanded Smartspace if the Target has extra options, available in Expanded Smartspace. Tapping the Target again in Expanded Smartspace will run the Target\'s original action.</string>
     <string name="expanded_settings_open_mode_always_title">Always</string>
     <string name="expanded_settings_open_mode_always_content">Always opens Expanded Smartspace. Tapping the Target again in Expanded Smartspace will run the Target\'s original action.</string>
+    <string name="expanded_settings_date_info"><b>Note:</b> Due to system limitations, this option does not apply to tapping the date from the Date Target (or a filler date Target shown above Complications)</string>
 
     <string name="expanded_settings_tint_colour">Tint Colour</string>
     <string name="expanded_settings_tint_colour_content">The colour to use for text and icons on Expanded Smartspace: %1s</string>

--- a/app/src/main/res/xml/widget_smartspacer.xml
+++ b/app/src/main/res/xml/widget_smartspacer.xml
@@ -5,7 +5,7 @@
     android:targetCellWidth="4"
     android:targetCellHeight="1"
     android:maxResizeWidth="99999dp"
-    android:maxResizeHeight="80dp"
+    android:maxResizeHeight="100dp"
     android:updatePeriodMillis="86400000"
     android:description="@string/widget_description_smartspacer"
     android:resizeMode="vertical|horizontal"


### PR DESCRIPTION
- Added compatibility for third party system launchers with Smartspace support (eg. Evolution X Launcher)
- Added warning about how the open mode options for Expanded Smartspace do not work for Date Targets
- Fixed a bug where the wrong information about Restricted Settings may have been shown on some devices
- Improved Safe Mode detection
- Added more information to the dump option, to help with debugging