### PR TITLE
1.4.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ plugins {
 
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
-def tagName = '1.4.1'
-def tagCode = 141
+def tagName = '1.4.2'
+def tagCode = 142
 
 android {
     compileSdk 34

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/targets/CalendarTarget.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/targets/CalendarTarget.kt
@@ -278,7 +278,7 @@ class CalendarTarget: SmartspacerTargetProvider() {
         @SerializedName("show_location")
         val showLocation: Boolean = true,
         @SerializedName("show_unconfirmed")
-        val showUnconfirmed: Boolean = false,
+        val showUnconfirmed: Boolean = true,
         @SerializedName("use_alternative_event_ids")
         val useAlternativeEventIds: Boolean = false,
         @SerializedName("calendars")

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/targets/NotificationTarget.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/targets/NotificationTarget.kt
@@ -4,7 +4,6 @@ import android.app.Notification
 import android.content.ComponentName
 import android.content.Context
 import android.service.notification.StatusBarNotification
-import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import com.kieronquinn.app.smartspacer.BuildConfig
@@ -44,8 +43,8 @@ class NotificationTarget: SmartspacerTargetProvider() {
 
     override fun getSmartspaceTargets(smartspacerId: String): List<SmartspaceTarget> {
         val settings = getSettings(smartspacerId) ?: return emptyList()
-        return getNotifications(smartspacerId).also {
-        }.map { it.toTarget() }.applyAppShortcuts(settings.packageName)
+        return getNotifications(smartspacerId).map { it.toTarget() }
+            .applyAppShortcuts(settings.packageName)
     }
 
     override fun getConfig(smartspacerId: String?): Config {
@@ -102,7 +101,8 @@ class NotificationTarget: SmartspacerTargetProvider() {
             sourceNotificationKey = key
             isSensitive = notification.visibility == Notification.VISIBILITY_SECRET
             val actions = notification.actions?.filter {
-                it.actionIntent != null
+                it.actionIntent != null && !it.remoteInputs.isNullOrEmpty()
+                        && !it.dataOnlyRemoteInputs.isNullOrEmpty()
             }?.map {
                 Shortcuts.Shortcut(
                     it.title,

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/service/SmartspacerNotificationWidgetService.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/service/SmartspacerNotificationWidgetService.kt
@@ -1,5 +1,6 @@
 package com.kieronquinn.app.smartspacer.service
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
@@ -55,7 +56,11 @@ class SmartspacerNotificationWidgetService: LifecycleService() {
         fun startServiceIfNeeded(context: Context) {
             if(isServiceRunning(context)) return
             val intent = Intent(context, SmartspacerNotificationWidgetService::class.java)
-            context.startForegroundService(intent)
+            try {
+                context.startForegroundService(intent)
+            }catch (e: Exception) {
+                //Not allowed to start
+            }
         }
 
         fun stopService(context: Context) {

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/configuration/calendar/CalendarTargetConfigurationFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/configuration/calendar/CalendarTargetConfigurationFragment.kt
@@ -116,7 +116,7 @@ class CalendarTargetConfigurationFragment: BaseSettingsFragment(), BackAvailable
             GenericSettingsItem.SwitchSetting(
                 targetData.showUnconfirmed,
                 getString(R.string.target_calendar_settings_show_unconfirmed_title),
-                getString(R.string.target_calendar_settings_show_unconfirmed_content),
+                getText(R.string.target_calendar_settings_show_unconfirmed_content),
                 ContextCompat.getDrawable(
                     requireContext(), R.drawable.ic_target_calendar_settings_show_unconfirmed
                 ),

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Erstelle IDs für jedes Ereignis basierend auf deren Titel, Start- und Endzeiten anstelle der systembereitgestellten IDs, wenn Ereignisse abgelehnt werden. Dies ist nützlich, wenn du eine App oder einen Dienst verwendest, der Kalender zwischen Konten synchronisiert und bei Änderungen neue Ereignisse erstellt.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Mostrar ubicación</string>
     <string name="target_calendar_settings_show_location_content">Mostrar ubicación de eventos, cuando esté disponible</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Mostrar no confirmado</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Mostrar eventos que no has marcado como asistencia confirmada</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Afficher le lieu</string>
     <string name="target_calendar_settings_show_location_content">Afficher le lieu des événements, s\'il est disponible</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Afficher les événements non confirmés</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Afficher les événements dont vous n\'avez pas confirmé votre présence</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Utiliser les identifiants d\'événement alternatifs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Créer des identifiants pour chacun des événements à partir de leur titre et de leur date de début et de fin, plutôt qu\'utiliser les identifiants fournis par le système, au moment d\'ignorer des événements. Cela peut être utile si vous utilisez une application ou un service qui « synchronise » les agendas entre les comptes, et recrée des événements à chaque modification.</string>
     <string name="target_calendar_settings_pre_event_time_title">Durée d\'affichage d\'un événement avant son début</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -866,7 +866,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Показать место</string>
     <string name="target_calendar_settings_show_location_content">Показать места проведения событий, где это возможно</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Показать непосещённые</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Показать события, которые вы не отметили как посещённые</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Использовать альтернативные ID события</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Создавать идентификаторы для каждого события на основе их названия, времени начала и окончания, вместо использования системных, при отклонении событий. Это полезно, если вы используете приложение или службу, которые синхронизируют календари между аккаунтами, и пересоздают новые события при изменениях.</string>
     <string name="target_calendar_settings_pre_event_time_title">Показать событие за время до начала</string>

--- a/app/src/main/res/values-sr-rSP/strings.xml
+++ b/app/src/main/res/values-sr-rSP/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">显示地点</string>
     <string name="target_calendar_settings_show_location_content">如果可用则显示事件地点</string>
     <string name="target_calendar_settings_show_unconfirmed_title">显示未确认事件</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">显示你还没有标记为确认参加的事件</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">使用替代事件 ID</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">消除事件时不使用系统提供的 ID，而是基于标题、开始和结束时间为每个事件创建 ID。当你借助应用或服务在多个账户间同步日历时很有用，这种方式会在细节变动时自动帮你创建新的事件。</string>
     <string name="target_calendar_settings_pre_event_time_title">在开始前显示事件时间</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -885,7 +885,6 @@
     <string name="target_calendar_settings_show_location_title">顯示地點</string>
     <string name="target_calendar_settings_show_location_content">顯示可用的事件地點</string>
     <string name="target_calendar_settings_show_unconfirmed_title">顯示未確認</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">顯示您尚未標記為已確認出席的事件</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">使用替代事件 ID</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">在駁回事件時，根據事件的標題、開始和結束時間而不是系統提供的 ID，為每個事件創建 ID。這在您使用應用程式或服務同步行事曆帳戶間，並在事情改變時重新創建新事件時非常有用。</string>
     <string name="target_calendar_settings_pre_event_time_title">在開始前顯示事件時間</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -977,7 +977,7 @@
     <string name="target_calendar_settings_show_location_title">Show Location</string>
     <string name="target_calendar_settings_show_location_content">Show event locations, where available</string>
     <string name="target_calendar_settings_show_unconfirmed_title">Show Unconfirmed</string>
-    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance</string>
+    <string name="target_calendar_settings_show_unconfirmed_content">Show events which you have not marked as confirmed attendance.\n<b>Important:</b> Some calendars do not support this function and disabling this will hide all events.</string>
     <string name="target_calendar_settings_use_alternative_event_id_title">Use Alternative Event IDs</string>
     <string name="target_calendar_settings_use_alternative_event_id_content">Create IDs for each event based on their title, start and end times rather than the system-provided IDs, when dismissing events. This is useful if you use an app or service which \'syncs\' Calendars between accounts, and re-creates new events when things change.</string>
     <string name="target_calendar_settings_pre_event_time_title">Show event for time before start</string>


### PR DESCRIPTION
- Calendar Target now defaults to showing unconfirmed due to OEMs not supporting the confirmation system 
- Notification Target no longer shows input only actions (which did nothing) 
- Crash fixes