### PR TITLE
fix wrong title and description in notification channels

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/smartspacer/components/notifications/Notifications.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/components/notifications/Notifications.kt
@@ -68,8 +68,8 @@ enum class NotificationChannel(
     SHIZUKU(
         "shizuku",
         NotificationManager.IMPORTANCE_HIGH,
-        R.string.notification_channel_native_title,
-        R.string.notification_channel_native_content
+        R.string.notification_channel_shizuku_reminder_title,
+        R.string.notification_channel_shizuku_reminder_content
     ),
     OEM(
         "oem",


### PR DESCRIPTION
In the notification channels (Smartspacer > App info > Notifications) native mode was shown twice, because the Shizuku channel had the title and description of the native mode channel, this fixes that error.