### PR TITLE
Allow Smartspacer to be digital assistant

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -150,6 +150,13 @@
             <intent-filter>
                 <action android:name="com.kieronquinn.app.smartspacer.SMARTSPACE" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+            <meta-data android:name="android.voice_interaction"
+                android:value="true" />
         </activity-alias>
 
         <activity


### PR DESCRIPTION
Hello. In this pull request I have added ability to call smart spacer as an assistant(i.e. by long press of home button). This option should be enabled by user in device setting(Smartspacer should be selected as digital assistant app). This feature is useful on devices without google services which consequently do not have Google Assistant as a more convenient way of calling smartspace from any app