### PR TITLE
Changed the initial value of `numPages` to 0, to avoid crash when setting tint before the page indicator has been properly initialised

### DIFF
--- a/sdk-client/src/main/java/com/kieronquinn/app/smartspacer/sdk/client/views/PageIndicator.kt
+++ b/sdk-client/src/main/java/com/kieronquinn/app/smartspacer/sdk/client/views/PageIndicator.kt
@@ -30,7 +30,7 @@ class PageIndicator @JvmOverloads constructor(
 
     private val primaryColor = context.getAttrColor(android.R.attr.textColorPrimary)
     private var currentPageIndex = -1
-    private var numPages = -1
+    private var numPages = 0
 
     private val defaultTintColour by lazy {
         context.getAttrColor(android.R.attr.textColorPrimary)


### PR DESCRIPTION
when calling `setTintColour` I got a crash, which came from `removeViewAt(0)` in `initializePageIndicators()`, where it seems that the `childCount - numPages` operation with numPages being -1 made it try to remove a child that didn't exist