### PR TITLE
Re-style widget to MaterialYou

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/smartspacer/model/database/AppWidget.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/model/database/AppWidget.kt
@@ -72,7 +72,12 @@ data class AppWidget(
      *  they're just invisible.
      */
     @ColumnInfo("hide_controls")
-    val hideControls: Boolean = false
+    val hideControls: Boolean = false,
+    /**
+     * Whether the widget is MaterialYou styled
+     */
+    @ColumnInfo("materialyou_styled")
+    val materialYouStyled: Boolean = false,
 ): Parcelable {
 
     fun cloneWithId(newAppWidgetId: Int): AppWidget {

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/model/database/SmartspacerDatabase.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/model/database/SmartspacerDatabase.kt
@@ -23,7 +23,7 @@ import com.kieronquinn.app.smartspacer.utils.room.GsonConverter
     Target::class,
     TargetData::class,
     Widget::class
-], version = 8, exportSchema = false)
+], version = 9, exportSchema = false)
 @TypeConverters(GsonConverter::class)
 abstract class SmartspacerDatabase: RoomDatabase() {
 
@@ -40,7 +40,8 @@ abstract class SmartspacerDatabase: RoomDatabase() {
                 MIGRATION_4_5,
                 MIGRATION_5_6,
                 MIGRATION_6_7,
-                MIGRATION_7_8
+                MIGRATION_7_8,
+                MIGRATION_8_9,
             ).build()
         }
 
@@ -87,6 +88,12 @@ abstract class SmartspacerDatabase: RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE AppWidget ADD COLUMN padding INTEGER NOT NULL DEFAULT '0'")
                 db.execSQL("ALTER TABLE AppWidget ADD COLUMN hide_controls INTEGER NOT NULL DEFAULT '0'")
+            }
+        }
+
+        private val MIGRATION_8_9 = object: Migration(8, 9){
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE AppWidget ADD COLUMN materialyou_styled INTEGER NOT NULL DEFAULT '0'")
             }
         }
     }

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/configuration/widget/WidgetConfigurationFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/configuration/widget/WidgetConfigurationFragment.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.graphics.Typeface
+import android.os.Build
 import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
@@ -437,6 +438,16 @@ class WidgetConfigurationFragment: BoundFragment<FragmentWidgetConfigurationBind
                 onChanged = viewModel::onShadowChanged
             ).takeIf {
                 widget.tintColour == TintColour.AUTOMATIC || widget.tintColour == TintColour.WHITE
+            },
+            SwitchSetting(
+                widget.materialYouStyled,
+                getString(R.string.widget_material_you_description),
+                getString(R.string.widget_material_you_title),
+                null,
+                true,
+                onChanged = viewModel::onMaterialYouChanged
+            ).takeIf {
+                !widget.listMode && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
             }
         )
     }

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/configuration/widget/WidgetConfigurationViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/configuration/widget/WidgetConfigurationViewModel.kt
@@ -45,6 +45,7 @@ abstract class WidgetConfigurationViewModel: ViewModel() {
     abstract fun onTintColourChanged(tintColour: TintColour)
     abstract fun onShadowChanged(enabled: Boolean)
     abstract fun onPaddingChanged(padding: Int)
+    abstract fun onMaterialYouChanged(enabled: Boolean)
 
     abstract fun Context.getPagedWidget(
         appWidgetId: Int,
@@ -207,6 +208,12 @@ class WidgetConfigurationViewModelImpl(
     override fun onPaddingChanged(padding: Int) {
         updateAppWidget {
             copy(padding = padding)
+        }
+    }
+
+    override fun onMaterialYouChanged(enabled: Boolean){
+        updateAppWidget {
+            copy(materialYouStyled=enabled)
         }
     }
 

--- a/app/src/main/res/drawable-v31/rounded_widget_bg.xml
+++ b/app/src/main/res/drawable-v31/rounded_widget_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="40dp" /> <!-- Adjust the corner radius as needed -->
+    <solid android:color="@android:color/system_accent1_50" />
+</shape>

--- a/app/src/main/res/drawable/rounded_widget_bg.xml
+++ b/app/src/main/res/drawable/rounded_widget_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="40dp" /> <!-- Adjust the corner radius as needed -->
+    <solid android:color="@android:color/darker_gray" />
+</shape>

--- a/app/src/main/res/layout/widget_smartspacer.xml
+++ b/app/src/main/res/layout/widget_smartspacer.xml
@@ -7,6 +7,7 @@
     android:clipToOutline="true">
 
     <LinearLayout
+        android:id="@+id/widget_status_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:animateLayoutChanges="true"
@@ -46,6 +47,7 @@
         android:layout_gravity="end|bottom"
         android:animateLayoutChanges="true"
         android:orientation="horizontal"
+        android:layout_marginEnd="8dp"
         android:paddingStart="@dimen/margin_8"
         android:paddingEnd="@dimen/margin_8">
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1225,5 +1225,7 @@
     <string name="fitness_widget_recommendation_category_label">Health &amp; fitness</string>
     <string name="news_widget_recommendation_category_label">News &amp; magazines</string>
     <string name="others_widget_recommendation_category_label">Suggested for you</string>
+    <string name="widget_material_you_description">MaterialYou style</string>
+    <string name="widget_material_you_title">Use dynamic MaterialYou styling for widget</string>
 
 </resources>


### PR DESCRIPTION
This pull-request adds option to style the widget in MaterialYou way on S+ devices. This styling may be enabled on non-list widgets via widget configuration. 
Screenshots below show the results
![Screenshot_20250205-003505_Trebuchet](https://github.com/user-attachments/assets/bfa78cb5-e6ce-439b-ad9e-eb29bd9f9de8)
![Screenshot_20250205-002559](https://github.com/user-attachments/assets/1bf99298-e40d-4682-b711-43b486a65557)
