### PR TITLE
fix music target not working with Gramophone

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/targets/MusicTarget.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/targets/MusicTarget.kt
@@ -225,7 +225,7 @@ class MusicTarget: SmartspacerTargetProvider() {
             containsKey(METADATA_KEY_ART) -> {
                 getBitmap(METADATA_KEY_ART)
             }
-            containsKey(METADATA_KEY_ART_URI) -> {
+            containsKey(METADATA_KEY_ART_URI) && getString(METADATA_KEY_ART_URI) != null -> {
                 val uri = Uri.parse(getString(METADATA_KEY_ART_URI))
                 val inputStream = provideContext().contentResolver.openInputStream(uri)
                     ?: return null
@@ -236,7 +236,7 @@ class MusicTarget: SmartspacerTargetProvider() {
             containsKey(METADATA_KEY_ALBUM_ART) -> {
                 getBitmap(METADATA_KEY_ALBUM_ART)
             }
-            containsKey(METADATA_KEY_ALBUM_ART_URI) -> {
+            containsKey(METADATA_KEY_ALBUM_ART_URI) && getString(METADATA_KEY_ALBUM_ART_URI) != null -> {
                 val uri = Uri.parse(getString(METADATA_KEY_ALBUM_ART_URI))
                 val inputStream = provideContext().contentResolver.openInputStream(uri)
                     ?: return null

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/model/smartspace/Target.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/model/smartspace/Target.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.Icon
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
+import android.util.Log
 import android.widget.Toast
 import androidx.core.os.bundleOf
 import com.google.gson.annotations.SerializedName
@@ -176,6 +177,7 @@ class Target(
             contentResolver?.callSafely(authority, method, null, extras)
         }catch (e: Throwable){
             //Provider has gone
+            Log.w("Target", Log.getStackTraceString(e))
             null
         }
     }


### PR DESCRIPTION
System can put null string into uri key in some cases: https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/services/core/java/com/android/server/media/MediaSessionRecord.java;l=1276;drc=32af37d886d9534362faee74e3456cf446194901 This exception is triggered due to AOSP bug, null String is added and Smartspacer can't load Music Target due to NPE.