### PR TITLE
1.11.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ plugins {
 
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
-def tagName = '1.11'
-def tagCode = 1110
+def tagName = '1.11.1'
+def tagCode = 1111
 
 android {
     compileSdkVersion 37

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/ExpandedSmartspacerSession.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/ExpandedSmartspacerSession.kt
@@ -11,7 +11,6 @@ import android.content.pm.ParceledListSlice
 import android.content.pm.ShortcutInfo
 import android.graphics.Bitmap
 import android.os.DeadObjectException
-import android.util.Log
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import com.kieronquinn.app.smartspacer.components.smartspace.ExpandedSmartspacerSession.Companion.MAX_SHORTCUTS
@@ -392,7 +391,6 @@ class ExpandedSmartspacerSession(
             }?.let {
                 Complication.Action(target, it)
             }
-            Log.d("ESS", "Got ${primary?.getTitle()}, ${header?.getTitle()}, ${base?.getTitle()}")
             listOfNotNull(primary, header, base)
         }.filter {
             it.isValid()

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/compat/TargetMerger.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/components/smartspace/compat/TargetMerger.kt
@@ -92,9 +92,12 @@ abstract class TargetMerger {
         return prefixedTargets + getSplitTargets(actionQueue) + uniqueTargets.mapNotNull {
             val pageActions = ArrayList<Action>()
             var target = it.target
-            val canTakePrimaryItem = target.canTakePrimaryItem(
-                actionQueue.peek(), supportsRemoteViews, complicationOnPrimary
-            )
+            // Never place a primary item if there's only one complication available
+            val canTakePrimaryItem = if (actionQueue.size > 1) {
+                target.canTakePrimaryItem(
+                    actionQueue.peek(), supportsRemoteViews, complicationOnPrimary
+                )
+            } else false
             val primaryAction = if (canTakePrimaryItem) {
                 actionQueue.pop()
             } else null
@@ -284,16 +287,14 @@ abstract class TargetMerger {
         complicationOnPrimary: ComplicationOnPrimary
     ) {
         while (actionQueue.isNotEmpty()) {
-            val showOnPrimary = actionQueue.peek()?.action?.showOnPrimary(complicationOnPrimary)
-            var primaryAction = if (showOnPrimary == true) {
+            // Never place primary item if there's only one complication
+            val showOnPrimary = actionQueue.size > 1 &&
+                    (actionQueue.peek()?.action?.showOnPrimary(complicationOnPrimary) ?: false)
+            val primaryAction = if (showOnPrimary) {
                 actionQueue.pop()
             } else null
-            var action = actionQueue.popOrNull()
+            val action = actionQueue.popOrNull()
             if (primaryAction == null && action == null) break
-            if (action == null) {
-                action = primaryAction
-                primaryAction = null
-            }
             val secondAction = actionQueue.popOrNull()
             val page = SmartspacePageHolder(
                 createBlankTarget(

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/ExpandedFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/ExpandedFragment.kt
@@ -711,6 +711,9 @@ class ExpandedFragment: BoundFragment<FragmentExpandedBinding>(
         popup.isFocusable = true
         popup.isAttachedInDecor = false
         popup.showAsDropDown(view)
+        popupView.root.setOnClickListener {
+            popup.dismiss()
+        }
         blurJob = whenResumed {
             popupView.root.awaitPost()
             blurs.firstOrNull()?.blurAvailable?.collect { available ->

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/ExpandedSession.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/expanded/ExpandedSession.kt
@@ -10,7 +10,9 @@ import com.kieronquinn.app.smartspacer.sdk.model.SmartspaceSessionId
 import com.kieronquinn.app.smartspacer.sdk.model.SmartspaceTarget
 import com.kieronquinn.app.smartspacer.sdk.model.SmartspaceTargetEvent
 import com.kieronquinn.app.smartspacer.sdk.model.uitemplatedata.BaseTemplateData
+import com.kieronquinn.app.smartspacer.sdk.model.uitemplatedata.Icon
 import com.kieronquinn.app.smartspacer.ui.screens.expanded.ExpandedSession.State
+import com.kieronquinn.app.smartspacer.utils.extensions.getBitmap
 import com.kieronquinn.app.smartspacer.utils.extensions.lockscreenShowing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.UUID
+import android.graphics.drawable.Icon as AndroidIcon
 
 interface ExpandedSession {
 
@@ -82,7 +85,7 @@ interface ExpandedSession {
                 }
 
                 override fun isValid(): Boolean {
-                    return smartspaceAction.icon != null || smartspaceAction.title.isNotBlank()
+                    return !smartspaceAction.icon.isNullOrBlank() || smartspaceAction.title.isNotBlank()
                 }
 
                 override fun getTitle(): String {
@@ -108,7 +111,7 @@ interface ExpandedSession {
                 }
 
                 override fun isValid(): Boolean {
-                    return info.icon != null || info.text?.text?.isNotBlank() == true
+                    return !info.icon.isNullOrBlank() || info.text?.text?.isNotBlank() == true
                 }
 
                 override fun getTitle(): String {
@@ -119,6 +122,14 @@ interface ExpandedSession {
 
             abstract fun isValid(): Boolean
             abstract fun getTitle(): String
+
+            protected fun Icon?.isNullOrBlank(): Boolean {
+                return this == null || icon.isNullOrBlank()
+            }
+
+            protected fun AndroidIcon?.isNullOrBlank(): Boolean {
+                return this == null || getBitmap()?.let { it.width <= 1 && it.height <= 1 } == true
+            }
 
             enum class Type {
                 ACTION,

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/setup/expanded/SetupExpandedSmartspaceFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/ui/screens/setup/expanded/SetupExpandedSmartspaceFragment.kt
@@ -11,7 +11,7 @@ import com.kieronquinn.app.smartspacer.databinding.FragmentSetupExpandedBinding
 import com.kieronquinn.app.smartspacer.ui.base.BackAvailable
 import com.kieronquinn.app.smartspacer.ui.base.BoundFragment
 import com.kieronquinn.app.smartspacer.ui.screens.setup.expanded.SetupExpandedSmartspaceViewModel.State
-import com.kieronquinn.app.smartspacer.utils.extensions.getBackgroundForBlur
+import com.kieronquinn.app.smartspacer.utils.extensions.getForegroundForBlur
 import com.kieronquinn.app.smartspacer.utils.extensions.onApplyInsets
 import com.kieronquinn.app.smartspacer.utils.extensions.onChanged
 import com.kieronquinn.app.smartspacer.utils.extensions.onClicked
@@ -59,7 +59,7 @@ class SetupExpandedSmartspaceFragment: BoundFragment<FragmentSetupExpandedBindin
     }
 
     private fun setupSetting() = with(binding.setupExpandedOpenEnabled) {
-        card.setCardBackgroundColor(monet.getBackgroundForBlur(requireContext()))
+        card.setCardBackgroundColor(monet.getForegroundForBlur(requireContext()))
         itemSettingsSwitchTitle.setText(R.string.setup_expanded_open_title)
         itemSettingsSwitchContent.setText(R.string.setup_expanded_open_content)
         itemSettingsSwitchContent.isVisible = true

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+Icon.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+Icon.kt
@@ -1,11 +1,13 @@
 package com.kieronquinn.app.smartspacer.utils.extensions
 
 import android.graphics.Bitmap
+import android.graphics.drawable.IconHidden
 import android.os.Parcel
 import android.widget.ImageView
 import com.kieronquinn.app.smartspacer.providers.SmartspacerProxyContentProvider
 import com.kieronquinn.app.smartspacer.sdk.client.views.DoubleShadowImageView
 import com.kieronquinn.app.smartspacer.sdk.model.uitemplatedata.Icon
+import dev.rikka.tools.refine.Refine
 import android.app.smartspace.uitemplatedata.Icon as SystemIcon
 import android.graphics.drawable.Icon as AndroidIcon
 
@@ -75,6 +77,12 @@ fun Icon.isLoadable(): Boolean {
 fun Icon_createEmptyIcon(): AndroidIcon {
     val bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ALPHA_8)
     return AndroidIcon.createWithBitmap(bitmap)
+}
+
+fun AndroidIcon.getBitmap(): Bitmap? {
+    return if (type == AndroidIcon.TYPE_BITMAP || type == AndroidIcon.TYPE_ADAPTIVE_BITMAP) {
+        Refine.unsafeCast<IconHidden>(this).bitmap
+    } else null
 }
 
 fun ImageView.setShadowEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+MonetCompat.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+MonetCompat.kt
@@ -44,11 +44,13 @@ fun MaterialCardView.applyBackgroundSecondary(monet: MonetCompat) = with(monet) 
 }
 
 fun MonetCompat.getBackgroundForBlur(context: Context, darkMode: Boolean? = null): Int {
-    return if(darkMode ?: context.isDarkMode){
-        getMonetColors().accent2[900]?.toArgb() ?: getBackgroundColor(context)
-    }else{
-        getMonetColors().accent2[200]?.toArgb() ?: getBackgroundColor(context)
-    }.withAlpha(0.75f)
+    val isDarkMode = darkMode ?: context.isDarkMode
+    val light = getMonetColors().accent1[100]?.toArgb()
+    val dark = getMonetColors().accent1[800]?.toArgb()
+    if (light == null || dark == null) return getBackgroundColor(context)
+    val base = (if (isDarkMode) dark else light).withAlpha(0.5f)
+    val overlay = if (isDarkMode) light.withAlpha(0.15f) else Color.WHITE.withAlpha(0.32f)
+    return ColorUtils.compositeColors(base, overlay)
 }
 
 fun MonetCompat.getForegroundForBlur(context: Context): Int {

--- a/systemstubs/src/main/java/android/graphics/drawable/IconHidden.java
+++ b/systemstubs/src/main/java/android/graphics/drawable/IconHidden.java
@@ -1,0 +1,14 @@
+package android.graphics.drawable;
+
+import android.graphics.Bitmap;
+
+import dev.rikka.tools.refine.RefineAs;
+
+@RefineAs(Icon.class)
+public class IconHidden {
+
+    public Bitmap getBitmap() {
+        throw new RuntimeException("Stub!");
+    }
+
+}


### PR DESCRIPTION
- Tweaked blur to closer match the blur in Android 17 QPR1
- Fixed a Complication disappearing if showing next to the date is enabled and there's only one Complication to show on the date Target
- Fixed tapping to the left or right of the popup in Expanded Smartspace not dismissing the popup
- Hide Complication in the Expanded Smartspace cluster of Complications below the Targets if it's blank