### PR TITLE
Include templateData in SystemSmartspaceTarget.equalsCompat

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+SmartspaceTarget.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/utils/extensions/Extensions+SmartspaceTarget.kt
@@ -190,6 +190,7 @@ fun SystemSmartspaceTarget.equalsCompat(other: Any?): Boolean {
     if(other.associatedSmartspaceTargetId != associatedSmartspaceTargetId) return false
     if(other.sliceUri != sliceUri) return false
     if(other.widget != widget) return false
+    if(other.templateData != templateData) return false
     return true
 }
 


### PR DESCRIPTION
SystemSmartspacerSession.filterDistinct dedupes target lists with old.equalsCompat(new), but equalsCompat compares everything on the target EXCEPT templateData. Calendar targets are recomputed every minute by CalendarTargetAlarmReceiver, and the new "in N mins" string lands entirely inside templateData.primaryItem.text -- no other field on the target changes between consecutive ticks. equalsCompat returns true, distinctUntilChanged drops the emit, and any consumer that reads templateData sees the countdown freeze at the first push.

Concretely, two consecutive ticks for the same upcoming calendar event captured from a Pixel 9 Pro running this exact build:

```
  03:56:01  smartspaceTargetId           = CALENDAR-116712222
            headerAction                 = id=CALENDAR title='' subtitle='' contentDescription=''
            baseAction                   = id=WEATHER  title=14°C subtitle=14°C contentDescription='Clear night'
            creationTimeMillis           = 1782039000000
            expiryTimeMillis             = 1782041100000
            score                        = 0.0
            actionChips                  = []
            iconGrid                     = []
            featureType                  = 2
            isSensitive                  = true
            sourceNotificationKey        = ''
            componentName                = ComponentInfo{package_name/class_name}
            userHandle                   = UserHandle{0}
            associatedSmartspaceTargetId = null
            sliceUri                     = null
            widget                       = null
            templateData.primaryItem     = "Test Event in 24 mins"

  03:57:01  ...every field above byte-identical to 03:56:01...
            templateData.primaryItem     = "Test Event in 23 mins"
```

Every field equalsCompat looks at is identical between the two pushes, so equalsCompat returns true and the 03:57:01 emit is dropped. The fix adds templateData to the comparison.

Only SystemSmartspacerSession is affected -- other session types use the default Flow<List<T>>.filterDistinct (distinctUntilChanged on deepEquals), which catches templateData. That's why Smartspacer's own widget and the lockscreen AAG keep ticking; only consumers that go through the public SmartspaceManager (i.e. SystemSmartspacerSession) see the freeze.