### PR TITLE
Ignore secondary user ASI deaths

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/smartspacer/service/SmartspacerShizukuService.kt
+++ b/app/src/main/java/com/kieronquinn/app/smartspacer/service/SmartspacerShizukuService.kt
@@ -466,16 +466,18 @@ class SmartspacerShizukuService: ISmartspacerShizukuService.Stub() {
     private fun setupCrashListener() = scope.launch {
         activityManager.processDied().collect { uid ->
             if(suppressCrash) return@collect
+            val userId = UserHandle.getUserHandleForUid(uid).getIdentifier()
             val packages = packageManager.getPackagesForUid(uid) ?: return@collect
             packages.forEach { pkg ->
-                onPackageDied(pkg)
+                onPackageDied(pkg, userId)
             }
         }
     }
 
     @Synchronized
-    private fun onPackageDied(packageName: String) {
+    private fun onPackageDied(packageName: String, userId: Int) {
         if(packageName == PACKAGE_ASI) {
+            if(userId != getUserId()) return
             try {
                 crashListener?.onAsiStopped()
             }catch (e: RemoteException){


### PR DESCRIPTION
Fix #257

Process death callbacks can include ASI instances from Work Profile or Private Space users. Resolve the Android user from the process UID and only trigger the At A Glance reconnect path when ASI dies for the user whose Smartspace service Smartspacer replaced.